### PR TITLE
Fix/husky commands

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -14,7 +14,8 @@
     "test": "yarn test:typescript && yarn test:eslint",
     "test:eslint": "eslint .",
     "test:typescript": "tsc -p ./tsconfig.json --noEmit",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "postinstall": "node ./scripts/postinstall.js"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",

--- a/lib/package.json
+++ b/lib/package.json
@@ -14,8 +14,7 @@
     "test": "yarn test:typescript && yarn test:eslint",
     "test:eslint": "eslint .",
     "test:typescript": "tsc -p ./tsconfig.json --noEmit",
-    "prepare": "husky install",
-    "postinstall": "husky install && npx husky add .husky/pre-commit \"yarn test\" && npx husky add .husky/pre-push \"yarn test\""
+    "prepare": "husky install"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",

--- a/lib/scripts/postinstall.js
+++ b/lib/scripts/postinstall.js
@@ -1,0 +1,12 @@
+const { exec } = require("child_process");
+const fs = require("fs");
+
+console.log("testing");
+if (!fs.existsSync("./.husky/pre-commit")) {
+  exec(
+    'husky install && npx husky add .husky/pre-commit "yarn test" && npx husky add .husky/pre-push "yarn test"'
+  );
+  console.log("husky git hooks created");
+} else {
+  console.log("husky git hooks already present");
+}


### PR DESCRIPTION
PR is for zenhub ticket https://app.zenhub.com/workspaces/pickup-5ee6cbe39ef1ca001fefe69b/issues/playpickup/kickoff/19

I was only able to recreate issue after using npx @playpickup/kickoff your-project-name to create a project locally then add dependencies

for solution i made postinstall.js a script that only runs if husky git commands are not present

its probably up for debate if this is the best fix.